### PR TITLE
Update getMvals

### DIFF
--- a/R/getMvals.R
+++ b/R/getMvals.R
@@ -18,7 +18,7 @@
 getMvals <- function(x, minCov=3, minSamp=2, k=1) {
 
   # do any loci in the object have enough read coverage in enough samples? 
-  usable <- (rowSums(getCoverage(x) >= minCov) >= minSamp)
+  usable <- (DelayedMatrixStats::rowSums2(getCoverage(x) >= minCov) >= minSamp)
   if (!any(usable)) stop("No usable CpG loci ( >= minCov in >= minSamp )!")
     
   # construct a subset of the overall BSseq object with smoothed mvalues 
@@ -33,7 +33,7 @@ getSmoothedMvals <- function(x, k=1, minCov=3, maxFrac=0.5) {
   rownames(res) <- as.character(granges(x))
   makeNA <- getCoverage(x) < minCov 
   maxPct <- paste0(100 * maxFrac, "%")
-  tooManyNAs <- (colSums(makeNA)/nrow(x)) > maxFrac
+  tooManyNAs <- (DelayedMatrixStats::colSums2(makeNA)/nrow(x)) > maxFrac
   if (any(tooManyNAs)) {
     message(paste(colnames(x)[tooManyNAs],collapse=", ")," are >",maxPct," NA!")
   }


### PR DESCRIPTION
When more than a handful of samples are used, getMvals has some trouble with rowSums and colSums. Solution as proposed here: https://github.com/Bioconductor/DelayedArray/issues/16

Errors include:

```
Error: 'bplapply' receive data failed:
  error reading from connection
and
Error: failed to stop ‘SOCKcluster’ cluster: error writing to connection
and
Error in summary.connection(connection) : invalid connection
```

Seems to work now with 12 samples and ~19 M loci.