### PR TITLE
fix for dovetail reads in collapseToFragment

### DIFF
--- a/R/readEpibed.R
+++ b/R/readEpibed.R
@@ -228,7 +228,8 @@ readEpibed <- function(epibed, is.nome = FALSE,
 .collapseDovetail <- function(r1, r2,
                               is.nome = FALSE) {
   # first, check if end r2 > start r1
-  if (end(r2) > start(r1)) {
+  # or end r2 == start r1
+  if (end(r2) >= start(r1)) {
     w <- start(r1) - start(r2)
     r2_decode <- .split_rle(r2$CG_decode)
     r2_decode <- r2_decode[1:w]


### PR DESCRIPTION
It's possible for the end of R2 to be equal to the start of R1; in this case the reads overlap and the logic for 'properly paired' reads chokes. 