### PR TITLE
fix readBiscuit bug

### DIFF
--- a/R/readBiscuit.R
+++ b/R/readBiscuit.R
@@ -139,7 +139,7 @@ readBiscuit <- function(BEDfile,
   # Remove CpG sites with zero-coverage
   if(!params$sparse) {
     message("Excluding CpG sites with uniformly zero coverage...")
-    tbl <- tbl[rowSums(is.na(tbl)) == 0, ]
+    tbl <- tbl[rowSums(is.na(tbl)) == params$nSamples, ]
   }
 
   message("Loaded ", params$tbx$path, ". Creating bsseq object...", appendLF=FALSE)

--- a/R/readBiscuit.R
+++ b/R/readBiscuit.R
@@ -139,7 +139,7 @@ readBiscuit <- function(BEDfile,
   # Remove CpG sites with zero-coverage
   if(!params$sparse) {
     message("Excluding CpG sites with uniformly zero coverage...")
-    tbl <- tbl[rowSums(is.na(tbl)) == params$nSamples, ]
+    tbl <- tbl[rowSums(is.na(tbl)) < params$nSamples, ]
   }
 
   message("Loaded ", params$tbx$path, ". Creating bsseq object...", appendLF=FALSE)


### PR DESCRIPTION
readBiscuit includes a line designed to remove any sites with uniformly zero coverage. This seems to do the opposite of what was actually intended (removes sites that are not covered in **all** samples). 

`tbl <- tbl[rowSums(is.na(tbl)) == 0, ]`

should be 

`tbl <- tbl[rowSums(is.na(tbl)) < params$nSamples, ]`,

which selects only those rows where the # of `NA`s is less than the total number of samples.